### PR TITLE
fix: Use the released collector version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,11 @@ jobs:
       is_release: ${{ steps.release_or_pr.outputs.is_release }}
     steps:
       - id: release_or_pr
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           cat > /tmp/commit_message <<- EOF
-          ${{ github.event.head_commit.message }}
+          ${COMMIT_MESSAGE}
           EOF
           cat /tmp/commit_message
           # https://regex101.com/r/1z85UX/1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
       - name: Update roles readme
         run: |
-          find . -maxdepth 2 -type d -path './roles/**' -not -path '*/_*' | while read -r dir; do \
+          find . -maxdepth 2 -type d -path './roles/**' -not -path '*/_validate_vars' | while read -r dir; do \
             uv run aar-doc --output-mode=replace ${dir} markdown; \
           done
       - name: Create Pull Request

--- a/roles/_collector_install/README.md
+++ b/roles/_collector_install/README.md
@@ -1,6 +1,6 @@
 <!-- BEGIN_ANSIBLE_DOCS -->
 # Ansible Role: elastiflow.netobserv._collector_install
-Version: 0.0.1
+Version: 0.1.2
 
 Meta role for Elastiflow packages installation
 
@@ -10,7 +10,7 @@ Meta role for Elastiflow packages installation
 | Platform | Versions |
 | -------- | -------- |
 | EL | 8, 9 |
-| Ubuntu | 22.04, 24.04 |
+| Ubuntu | jammy, noble |
 
 ## Role Arguments
 

--- a/roles/netobserv_flow/README.md
+++ b/roles/netobserv_flow/README.md
@@ -26,7 +26,7 @@ Please see full documentation for:
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | netobserv_flow_install | Whether to install NetObserv Flow. | bool | no | `True` |
-| netobserv_flow_version | NetObserv Flow version to install. | str | no | `1:7.13.1-1` |
+| netobserv_flow_version | NetObserv Flow version to install. | str | no | `1:7.14.0-1` |
 | netobserv_flow_config_dir | Directory for NetObserv Flow configuration files. | str | no | `/etc/elastiflow` |
 | netobserv_flow_validate_vars | Validate variables before applying configuration. | bool | no | `True` |
 | netobserv_flow_config_file | Main configuration file for NetObserv Flow. | str | no | `{{ netobserv_flow_config_dir }}/flowcoll.yml` |

--- a/roles/netobserv_flow/defaults/main.yml
+++ b/roles/netobserv_flow/defaults/main.yml
@@ -3,7 +3,7 @@
 # Whether to install NetObserv Flow.
 netobserv_flow_install: true
 # NetObserv Flow version to install.
-netobserv_flow_version: '1:7.13.1-1'
+netobserv_flow_version: '1:7.14.0-1'
 # Directory for NetObserv Flow configuration files.
 netobserv_flow_config_dir: /etc/elastiflow
 # Validate variables before applying configuration.

--- a/roles/netobserv_flow/meta/argument_specs.yml
+++ b/roles/netobserv_flow/meta/argument_specs.yml
@@ -14,7 +14,7 @@ argument_specs:
 
       netobserv_flow_version:
         type: str
-        default: "1:7.13.1-1"
+        default: "1:7.14.0-1"
         description: |
           NetObserv Flow version to install.
 


### PR DESCRIPTION
# Description
The first stable version of the collectors published to the APT/YUM is `7.14`, setting it in the manifests
