### PR TITLE
fix: Drop "branch" from releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,7 @@ jobs:
         id: prepare_release
         uses: elastiflow/gha-reusable/actions/prepare-release@v0
         with:
-          changelog_update: true
-          bump_version_yaml: true
-          bump_version_yaml_path: galaxy.yml
-          bump_version_yaml_key: '.version'
+          add_git_notes: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create and push semver tag
         if: ${{ fromJson(steps.prepare_release.outputs.new_release_published) }}


### PR DESCRIPTION
# Description
[default](https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches) config is used, which can be overridden in the config
