### PR TITLE
fix: bump NetObserv Flow to 7.23.0

### DIFF
--- a/roles/netobserv_flow/README.md
+++ b/roles/netobserv_flow/README.md
@@ -127,7 +127,7 @@ The safest way to upgrade is:
 |Option|Description|Type|Required|Default|
 |---|---|---|---|---|
 | netobserv_flow_install | Whether to install NetObserv Flow. | bool | no | `True` |
-| netobserv_flow_version | NetObserv Flow version to install. | str | no | `1:7.20.0-1` |
+| netobserv_flow_version | NetObserv Flow version to install. | str | no | `1:7.23.0-1` |
 | netobserv_flow_config_dir | Directory for NetObserv Flow configuration files. | str | no | `/etc/elastiflow` |
 | netobserv_flow_config_file | Main configuration file for NetObserv Flow. | str | no | `{{ netobserv_flow_config_dir }}/flowcoll.yml` |
 | netobserv_flow_license | License configuration for NetObserv Flow collector. See: https://docs.elastiflow.com/flowcoll/configuration/config_gen/license ***defaults_prefix:"__"*** | dict of `netobserv_flow_license` [options](#options-for-main--netobserv_flow_license) | no |  |

--- a/roles/netobserv_flow/defaults/main.yml
+++ b/roles/netobserv_flow/defaults/main.yml
@@ -3,7 +3,7 @@
 # Whether to install NetObserv Flow.
 netobserv_flow_install: true
 # NetObserv Flow version to install.
-netobserv_flow_version: '1:7.20.0-1'
+netobserv_flow_version: '1:7.23.0-1'
 # Directory for NetObserv Flow configuration files.
 netobserv_flow_config_dir: /etc/elastiflow
 # Main configuration file for NetObserv Flow.

--- a/roles/netobserv_flow/meta/argument_specs.yml
+++ b/roles/netobserv_flow/meta/argument_specs.yml
@@ -116,7 +116,7 @@ argument_specs:
 
       netobserv_flow_version:
         type: str
-        default: "1:7.20.0-1"
+        default: "1:7.23.0-1"
         description: |
           NetObserv Flow version to install.
 


### PR DESCRIPTION
## Summary
- Bump default NetObserv Flow collector version to 7.23.0.
